### PR TITLE
refactor: only use configs from Sanity

### DIFF
--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -16,7 +16,6 @@ config:
   pulumi:disable-default-providers:
     - '*'
   shared:domain: flexisoft.bjerk.dev.
-  shared:root-domain: bjerk.dev.
   shared:sanity-api-token:
     secure: AAABAKNUxuIL0P20L2+jSx+8ltTNOjlOc6QPadK5RvVmbRjvuyQdVE0usE8NDTvDULKHUvccqXXy8++71QO4+Knmr3f8Cm4f5jug/ArWfAh55OIU+l0ewtwczJatw781PQuDvBLz+Z9+Bn13sjSQpIJIpKUw+YCytxUA9o9vmhlGHtTAc3GnswmMOv5X5dUvvwe7NtDwrlRvkVw20kniJGqNZF2v1ETYbERDx/gm2f8d0H2jMqIMpqNykO1+YyD0kSo4YsQN02wW/kknQclxy/bkd/A=
   shared:sanity-project-id: w45ry00z

--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -10,10 +10,8 @@ config:
     secure: AAABAGNx2AH3V5QmwfBOzUjXpZ5OBSBNbdL+QgB0I5a37lHMMcsUVz+vl4snxg+thegbVzM0plRWgiALUupL88JvEkrLB4zodEhXFD4S9xNzOSZXkbUaXSroU/ZOoAhZ
   portal-api:cookie-secret:
     secure: AAABADy2iSkKwef0IiFd0IDXze14jO0VtDr6oM53MXgdadia3pK7wN0U2AArLuQ0GooGBzS6GxGuvCPSgZV2MdfaumwMzdzpoe1OHNN9jP5NGQaJP/RpQRPhlx4r3YnH
-  portal-api:domain: api.flexisoft.bjerk.dev.
   portal-api:log-level: debug
   portal-api:tag: main-d207772
-  portal-app:domain: flexisoft.bjerk.dev.
   portal-app:tag: main-65d2619
   pulumi:disable-default-providers:
     - '*'
@@ -23,4 +21,3 @@ config:
     secure: AAABAKNUxuIL0P20L2+jSx+8ltTNOjlOc6QPadK5RvVmbRjvuyQdVE0usE8NDTvDULKHUvccqXXy8++71QO4+Knmr3f8Cm4f5jug/ArWfAh55OIU+l0ewtwczJatw781PQuDvBLz+Z9+Bn13sjSQpIJIpKUw+YCytxUA9o9vmhlGHtTAc3GnswmMOv5X5dUvvwe7NtDwrlRvkVw20kniJGqNZF2v1ETYbERDx/gm2f8d0H2jMqIMpqNykO1+YyD0kSo4YsQN02wW/kknQclxy/bkd/A=
   shared:sanity-project-id: w45ry00z
   shared:studio-sub-domain: studio.flexisoft.bjerk.dev.
-  shared:wildcard-sub-domain: '*.flexisoft.bjerk.dev.'

--- a/docs/customers.md
+++ b/docs/customers.md
@@ -20,3 +20,9 @@ deploy the infrastructure to update the ingress resources.
 
 The ingress configures both API address (`api.<custom domain>`) and frontend on
 the custom domain.
+
+## The schema
+
+The schema is defined in the [studio repository][schema].
+
+[schema]: https://github.com/flexisoftorg/studio/blob/main/schemas/customer.ts

--- a/docs/customers.md
+++ b/docs/customers.md
@@ -3,8 +3,11 @@
 We utilize Sanity to configure the customer portal. This allows us to easily add
 and remove customers, and update their information.
 
-See the [Studio Repository](https://github.com/flexisoftorg/studio) for more
-information.
+See the [Studio Repository][studio-repo] for more
+information. Access [the studio website to manage customers][studio].
+
+[studio-repo]: https://github.com/flexisoftorg/studio
+[studio]: https://studio.flexisoft.bjerk.dev
 
 ## How this is wired
 

--- a/resources/config.ts
+++ b/resources/config.ts
@@ -1,11 +1,6 @@
 import * as pulumi from '@pulumi/pulumi';
 
 const config = new pulumi.Config();
-
 export const developers = config.requireObject<string[]>('developers');
-
 export const environment = pulumi.getStack();
 
-const portalAppConfig = new pulumi.Config('portal-app');
-
-export const portalAppDomain = portalAppConfig.require('domain');

--- a/resources/get-customers.ts
+++ b/resources/get-customers.ts
@@ -4,13 +4,13 @@ import { z } from 'zod';
 import { sanityApiToken, sanityProjectId } from './shared/config';
 
 const portalCustomer = z.object({
+  ident: z.object({
+    current: z.string(),
+  }),
   host: z.string(),
   name: z.string(),
   port: z.number(),
   database: z.string(),
-  slug: z.object({
-    current: z.string(),
-  }),
   domain: z.string().optional(),
 });
 
@@ -26,7 +26,9 @@ export function getCustomers(): pulumi.Output<PortalCustomer[]> {
       apiVersion: '2023-04-18',
     });
 
-    const result = await client.fetch("*[_type == 'customer']");
+    const result = await client.fetch(
+      "*[_type == 'customer' && !(_id in path('drafts.**'))]",
+    );
     return z.array(portalCustomer).parse(result);
   });
 }

--- a/resources/kubernetes/portal-api/portal-api.ts
+++ b/resources/kubernetes/portal-api/portal-api.ts
@@ -3,7 +3,6 @@ import * as pulumi from '@pulumi/pulumi';
 import { interpolate } from '@pulumi/pulumi';
 import { DeploymentComponent } from '../../components/deployment';
 import { customers } from '../../get-customers';
-import { rootDomain } from '../../shared/config';
 import { artifactRepoUrl } from '../../shared/google/artifact-registry';
 import { provider as kubernetesProvider } from '../../shared/kubernetes/provider';
 import { namespace } from './namespace';
@@ -55,17 +54,19 @@ export const portalApi = new DeploymentComponent(
       { configMapRef: { name: portalApiCustomerConfigMap.metadata.name } },
     ],
     env: [
-      // TODO: Remove once tenant configs are landed
+      // TODO: Remove FRONTEND_URL, SELF_URL and SELF_DOMAIN once tenant configs are added to API and Portal
       {
         name: 'FRONTEND_URL',
-        value: interpolate`https://flexisoft.bjerk.dev`,
+        value: 'https://flexisoft.bjerk.dev',
       },
+      { name: 'SELF_URL', value: 'https://api.flexisoft.bjerk.dev' },
+      { name: 'SELF_DOMAIN', value: 'https://flexisoft.bjerk.dev' },
+
       {
         name: 'LOG_LEVEL',
         value: config.get('log-level') || 'info',
       },
-      { name: 'SELF_DOMAIN', value: rootDomain.slice(0, -1) },
-      { name: 'SELF_URL', value: interpolate`https://${cleanPortalApiDomain}` },
+
       {
         name: 'REDIS_URL',
         value: interpolate`redis://${redis.service.metadata.name}.${redis.service.metadata.namespace}.svc.cluster.local:6379`,

--- a/resources/kubernetes/portal-app/config.ts
+++ b/resources/kubernetes/portal-app/config.ts
@@ -1,3 +1,0 @@
-import { portalAppDomain } from '../../config';
-
-export const cleanPortalApiDomain = portalAppDomain.slice(0, -1);

--- a/resources/kubernetes/portal-app/portal-app.ts
+++ b/resources/kubernetes/portal-app/portal-app.ts
@@ -2,6 +2,7 @@ import * as pulumi from '@pulumi/pulumi';
 import { interpolate } from '@pulumi/pulumi';
 import { DeploymentComponent } from '../../components/deployment';
 import { artifactRepoUrl } from '../../shared/google/artifact-registry';
+import { customerConfigMap } from '../../shared/kubernetes/customer-config';
 import { provider as kubernetesProvider } from '../../shared/kubernetes/provider';
 import { namespace } from './namespace';
 
@@ -13,6 +14,9 @@ export const portalApp = new DeploymentComponent(
     image: interpolate`${artifactRepoUrl}/portal-app`,
     tag: config.require('tag'),
     namespace: namespace.metadata.name,
+    envFrom: [
+      { configMapRef: { name: customerConfigMap.metadata.name } },
+    ],
     port: 8000,
     resources: {
       requests: {

--- a/resources/kubernetes/portal-app/portal-app.ts
+++ b/resources/kubernetes/portal-app/portal-app.ts
@@ -1,10 +1,8 @@
-import * as k8s from '@pulumi/kubernetes';
 import * as pulumi from '@pulumi/pulumi';
 import { interpolate } from '@pulumi/pulumi';
 import { DeploymentComponent } from '../../components/deployment';
 import { artifactRepoUrl } from '../../shared/google/artifact-registry';
 import { provider as kubernetesProvider } from '../../shared/kubernetes/provider';
-import { cleanPortalApiDomain } from './config';
 import { namespace } from './namespace';
 
 const config = new pulumi.Config('portal-app');
@@ -14,7 +12,6 @@ export const portalApp = new DeploymentComponent(
   {
     image: interpolate`${artifactRepoUrl}/portal-app`,
     tag: config.require('tag'),
-    host: cleanPortalApiDomain,
     namespace: namespace.metadata.name,
     port: 8000,
     resources: {
@@ -26,41 +23,6 @@ export const portalApp = new DeploymentComponent(
         cpu: '200m',
         memory: '256Mi',
       },
-    },
-  },
-  { provider: kubernetesProvider },
-);
-
-new k8s.networking.v1.Ingress(
-  'wildcard-ingress',
-  {
-    metadata: {
-      name: 'app-wildcard',
-      namespace: namespace.metadata.name,
-      annotations: {
-        'kubernetes.io/ingress.class': 'caddy',
-      },
-    },
-    spec: {
-      rules: [
-        {
-          host: `*.app.${cleanPortalApiDomain}`,
-          http: {
-            paths: [
-              {
-                path: '/',
-                pathType: 'Prefix',
-                backend: {
-                  service: {
-                    name: portalApp.service.metadata.name,
-                    port: { number: portalApp.port },
-                  },
-                },
-              },
-            ],
-          },
-        },
-      ],
     },
   },
   { provider: kubernetesProvider },

--- a/resources/kubernetes/portal-app/portal-domains.ts
+++ b/resources/kubernetes/portal-app/portal-domains.ts
@@ -11,10 +11,10 @@ customers.apply(customers =>
     .map(
       customer =>
         new k8s.networking.v1.Ingress(
-          `${customer.slug.current}-ingress`,
+          `${customer.ident.current}-ingress`,
           {
             metadata: {
-              name: `customer-${customer.slug.current}`,
+              name: `customer-${customer.ident.current}`,
               namespace: namespace.metadata.name,
               annotations: {
                 'kubernetes.io/ingress.class': 'caddy',

--- a/resources/shared/config.ts
+++ b/resources/shared/config.ts
@@ -3,7 +3,6 @@ import * as pulumi from '@pulumi/pulumi';
 const config = new pulumi.Config('shared');
 
 export const domain = config.require('domain');
-export const rootDomain = config.require('root-domain');
 export const studioSubDomain = config.require('studio-sub-domain');
 export const sanityApiToken = config.requireSecret('sanity-api-token');
 export const sanityProjectId = config.require('sanity-project-id');

--- a/resources/shared/config.ts
+++ b/resources/shared/config.ts
@@ -5,7 +5,5 @@ const config = new pulumi.Config('shared');
 export const domain = config.require('domain');
 export const rootDomain = config.require('root-domain');
 export const studioSubDomain = config.require('studio-sub-domain');
-export const wildcardSubDomain = config.require('wildcard-sub-domain');
-
 export const sanityApiToken = config.requireSecret('sanity-api-token');
 export const sanityProjectId = config.require('sanity-project-id');

--- a/resources/shared/google/dns.ts
+++ b/resources/shared/google/dns.ts
@@ -1,9 +1,7 @@
 import * as gcp from '@pulumi/gcp';
-import { portalAppDomain } from '../../config';
 import { apiServices } from '../../google/api-services';
 import { provider } from '../../google/provider';
-import { portalApiDomain } from '../../kubernetes/portal-api/portal-api';
-import { domain, studioSubDomain, wildcardSubDomain } from '../config';
+import { domain, studioSubDomain } from '../config';
 import { ipAddress } from './ip-address';
 
 const ingressIpAddress = ipAddress.address;
@@ -29,22 +27,10 @@ export const zone = new gcp.dns.ManagedZone(
  */
 
 new gcp.dns.RecordSet(
-  'portal-app-ipv4',
+  'tenant-api',
   {
     managedZone: zone.name,
-    name: portalAppDomain,
-    type: 'A',
-    ttl: 300,
-    rrdatas: [ingressIpAddress],
-  },
-  { provider },
-);
-
-new gcp.dns.RecordSet(
-  'portal-api',
-  {
-    managedZone: zone.name,
-    name: portalApiDomain,
+    name: `tenant.${domain}`,
     type: 'A',
     ttl: 300,
     rrdatas: [ingressIpAddress],
@@ -64,11 +50,27 @@ new gcp.dns.RecordSet(
   { provider },
 );
 
+/**
+ * Demo App DNS records
+ */
+
 new gcp.dns.RecordSet(
-  'wildcard',
+  'portal-app-ipv4',
   {
     managedZone: zone.name,
-    name: wildcardSubDomain,
+    name: domain,
+    type: 'A',
+    ttl: 300,
+    rrdatas: [ingressIpAddress],
+  },
+  { provider },
+);
+
+new gcp.dns.RecordSet(
+  'portal-api',
+  {
+    managedZone: zone.name,
+    name: `api.${domain}`,
     type: 'A',
     ttl: 300,
     rrdatas: [ingressIpAddress],

--- a/resources/shared/kubernetes/customer-config.ts
+++ b/resources/shared/kubernetes/customer-config.ts
@@ -1,0 +1,16 @@
+import * as kubernetes from '@pulumi/kubernetes';
+import { customers } from '../../get-customers';
+import { provider as kubernetesProvider } from './provider';
+
+export const customerConfigMap = new kubernetes.core.v1.ConfigMap(
+  'customer-config-map',
+  {
+    metadata: {
+      name: 'customer-config-map',
+    },
+    data: {
+      CUSTOMERS: customers.apply(customers => JSON.stringify(customers)),
+    },
+  },
+  { provider: kubernetesProvider },
+);


### PR DESCRIPTION
We should not mix too many concepts. By using Sanity for every and all configurations, we win.

AFAIK, this will deploy nicely without too much disruption.