### PR TITLE
fix: export portal api secrets

### DIFF
--- a/resources/kubernetes/portal-api/portal-api.ts
+++ b/resources/kubernetes/portal-api/portal-api.ts
@@ -18,7 +18,7 @@ const cookieSecret = config.requireSecret('cookie-secret');
 export const portalApiDomain = config.require('domain');
 const cleanPortalApiDomain = portalApiDomain.slice(0, -1);
 
-const portalApiEnvSecrets = new kubernetes.core.v1.Secret(
+export const portalApiEnvSecrets = new kubernetes.core.v1.Secret(
   'portal-api-env-secrets',
   {
     metadata: {


### PR DESCRIPTION
Trying to fix this error:
```
 Diagnostics:
    kubernetes:apps/v1:Deployment (portal-api):
      error: 3 errors occurred:
      	* the Kubernetes API server reported that "portal-prod/portal-api" failed to fully initialize or become live: 'portal-api' timed out waiting to be Ready
      	* Minimum number of live Pods was not attained
      	* [Pod portal-prod/portal-api-85479f58c-g928x]: containers with unready status: [api] -- [CreateContainerConfigError] secret "portal-api-env-secrets" not found
  
    pulumi:pulumi:Stack (flexisoft-portal-prod):
      error: update failed
```