### PR TITLE
feat: consume flexisoft secrets environment

### DIFF
--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -33,4 +33,4 @@ config:
   slack:bot-oauth-token:
     secure: AAABAP0i2LEFsOZ2YLW6LasJg7R1m+DaL0nhcByNCS8X6bgGE2zlkJLNS+rRfWvBvb88bBhEpx0m98fKKc2eeA==
 environment:
-  - secrets
+  - flexisoft-secrets

--- a/resources/github/config.ts
+++ b/resources/github/config.ts
@@ -2,5 +2,5 @@ import * as pulumi from '@pulumi/pulumi';
 
 const config = new pulumi.Config('github');
 
-export const token = config.requireSecret('flexisoftorg-token');
+export const token = config.requireSecret('githubToken');
 export const owner = config.require('owner');


### PR DESCRIPTION
We have a specific environment for flexisoft  secrets which we should (?) consume instead of the general secrets environment. However, I'm not sure if this environment currently holds a non-expired secret, so this PR may not solve anything in itself.