### PR TITLE
feat: add more data from sanity

### DIFF
--- a/resources/get-customers.ts
+++ b/resources/get-customers.ts
@@ -38,7 +38,12 @@ export function getCustomers(): pulumi.Output<PortalCustomer[]> {
           port,
           database,
           domain,
-          "logoUrl": logo.asset->url
+          "logoUrl": logo.asset->url,
+          organizationNumber,
+          phoneNumber,
+          email,
+          address,
+          description
       }
     `);
     const customers = result


### PR DESCRIPTION
this adds some fields that are added to sanity. This way, the data is sent as env variables for the debitor portal to show the relevant information, rather than `null` via tenant