### PR TITLE
fix: set resource values to legal value

### DIFF
--- a/resources/kubernetes/debitor-portal-app/debitor-portal-app.ts
+++ b/resources/kubernetes/debitor-portal-app/debitor-portal-app.ts
@@ -28,12 +28,12 @@ export const debitorPortalApp = new DeploymentComponent(
     ],
     resources: {
       requests: {
-        cpu: '100m',
-        memory: '128Mi',
+        cpu: '250m',
+        memory: '512Mi',
       },
       limits: {
-        cpu: '200m',
-        memory: '256Mi',
+        cpu: '250m',
+        memory: '512Mi',
       },
     },
   },

--- a/resources/kubernetes/portal-api/portal-api.ts
+++ b/resources/kubernetes/portal-api/portal-api.ts
@@ -60,12 +60,12 @@ export const portalApi = new DeploymentComponent(
     ],
     resources: {
       requests: {
-        cpu: '100m',
-        memory: '128Mi',
+        cpu: '250m',
+        memory: '512Mi',
       },
       limits: {
-        cpu: '200m',
-        memory: '256Mi',
+        cpu: '250m',
+        memory: '512Mi',
       },
     },
   },

--- a/resources/kubernetes/portal-api/redis.ts
+++ b/resources/kubernetes/portal-api/redis.ts
@@ -12,12 +12,12 @@ export const redis = new DeploymentComponent(
     port: 6379,
     resources: {
       requests: {
-        cpu: '100m',
-        memory: '128Mi',
+        cpu: '250m',
+        memory: '512Mi',
       },
       limits: {
-        cpu: '200m',
-        memory: '256Mi',
+        cpu: '250m',
+        memory: '512Mi',
       },
     },
   },

--- a/resources/kubernetes/portal-app/portal-app.ts
+++ b/resources/kubernetes/portal-app/portal-app.ts
@@ -18,12 +18,12 @@ export const portalApp = new DeploymentComponent(
     envFrom: [{ configMapRef: { name: customerConfigMap.metadata.name } }],
     resources: {
       requests: {
-        cpu: '100m',
-        memory: '128Mi',
+        cpu: '250m',
+        memory: '512Mi',
       },
       limits: {
-        cpu: '200m',
-        memory: '256Mi',
+        cpu: '250m',
+        memory: '512Mi',
       },
     },
   },


### PR DESCRIPTION
In every action run, such as [this one](https://app.pulumi.com/bjerk/flexisoft-portal/prod/previews/7282c635-d77a-48a9-992b-42e1a2fa39b4), we see that pulumi is trying to change the resources values in every deployment, but it's not sticking. Time and time again, we see that the actual values in the state are 

```ts
      limits: {
        cpu: '250m',
        memory: '512Mi',
      },
```