### PR TITLE
fix: make it work

### DIFF
--- a/resources/get-customers.ts
+++ b/resources/get-customers.ts
@@ -12,7 +12,7 @@ const portalCustomer = z.object({
   name: z.string(),
   port: z.number(),
   database: z.string(),
-  domain: z.string().optional(),
+  domain: z.string().nullable(),
   logoUrl: z.string().nullable(),
   organizationNumber: z.string().nullish(),
   phoneNumber: z.string().nullish(),

--- a/resources/kubernetes/portal-app/portal-domains.ts
+++ b/resources/kubernetes/portal-app/portal-domains.ts
@@ -10,11 +10,13 @@ import { portalApp } from './portal-app';
 import { ingressIpAddress, zone } from '../../shared/google/dns';
 import { rootDomain } from '../../shared/config';
 
+const cleanRootDomain = rootDomain.slice(0, -1);
+
 customers.apply(customers =>
   customers.map(customer => {
     const domain = customer.domain
       ? customer.domain
-      : `${customer.ident.current}.${rootDomain}`;
+      : `${customer.ident.current}.${cleanRootDomain}`;
 
     const hasCustomDomain = Boolean(customer.domain?.trim());
 

--- a/resources/kubernetes/portal-app/portal-domains.ts
+++ b/resources/kubernetes/portal-app/portal-domains.ts
@@ -13,7 +13,7 @@ import { ingressIpAddress, zone } from '../../shared/google/dns';
 customers.apply(customers =>
   customers.map(customer => {
     const domain = customer.domain
-      ? customer.domain
+      ? `${customer.domain}.`
       : `${customer.ident.current}.${rootDomain}`;
 
     const hasCustomDomain = Boolean(customer.domain?.trim());

--- a/resources/kubernetes/portal-app/portal-domains.ts
+++ b/resources/kubernetes/portal-app/portal-domains.ts
@@ -1,6 +1,7 @@
 import * as k8s from '@pulumi/kubernetes';
 import * as gcp from '@pulumi/gcp';
 import { customers } from '../../get-customers';
+import { provider as gcpProvider } from '../../google/provider';
 import { provider } from '../../shared/kubernetes/provider';
 import { debitorPortalApp } from '../debitor-portal-app/debitor-portal-app';
 import { namespace } from '../namespace';
@@ -33,7 +34,7 @@ customers.apply(customers =>
           ttl: 300,
           rrdatas: [ingressIpAddress],
         },
-        { provider },
+        { provider: gcpProvider },
       );
       new gcp.dns.RecordSet(
         `${customer.ident.current}-debitor-portal`,
@@ -44,7 +45,7 @@ customers.apply(customers =>
           ttl: 300,
           rrdatas: [ingressIpAddress],
         },
-        { provider },
+        { provider: gcpProvider },
       );
 
       new gcp.dns.RecordSet(
@@ -56,7 +57,7 @@ customers.apply(customers =>
           ttl: 300,
           rrdatas: [ingressIpAddress],
         },
-        { provider },
+        { provider: gcpProvider },
       );
     }
 

--- a/resources/kubernetes/portal-app/portal-domains.ts
+++ b/resources/kubernetes/portal-app/portal-domains.ts
@@ -2,21 +2,19 @@ import * as k8s from '@pulumi/kubernetes';
 import * as gcp from '@pulumi/gcp';
 import { customers } from '../../get-customers';
 import { provider as gcpProvider } from '../../google/provider';
+import { rootDomain } from '../../shared/config';
 import { provider } from '../../shared/kubernetes/provider';
 import { debitorPortalApp } from '../debitor-portal-app/debitor-portal-app';
 import { namespace } from '../namespace';
 import { portalApi } from '../portal-api/portal-api';
 import { portalApp } from './portal-app';
 import { ingressIpAddress, zone } from '../../shared/google/dns';
-import { rootDomain } from '../../shared/config';
-
-const cleanRootDomain = rootDomain.slice(0, -1);
 
 customers.apply(customers =>
   customers.map(customer => {
     const domain = customer.domain
       ? customer.domain
-      : `${customer.ident.current}.${cleanRootDomain}`;
+      : `${customer.ident.current}.${rootDomain}`;
 
     const hasCustomDomain = Boolean(customer.domain?.trim());
 
@@ -82,7 +80,7 @@ customers.apply(customers =>
         spec: {
           rules: [
             {
-              host: creditorPortalDomain,
+              host: creditorPortalDomain.slice(0, -1),
               http: {
                 paths: [
                   {
@@ -99,7 +97,7 @@ customers.apply(customers =>
               },
             },
             {
-              host: apiDomain,
+              host: apiDomain.slice(0, -1),
               http: {
                 paths: [
                   {
@@ -116,7 +114,7 @@ customers.apply(customers =>
               },
             },
             {
-              host: debitorPortalDomain,
+              host: debitorPortalDomain.slice(0, -1),
               http: {
                 paths: [
                   {


### PR DESCRIPTION
- Change customer schema since Sanity returns `null` when the field is undefined, not undefined
- use gcp provider for DNS, not kubernetes provider
- ensure correct handling of trailing periods in domains for DNS and ingress rules for customers