### PR TITLE
feat: populate domain field in customers without custom domain in sanity, specify specific domains

### DIFF
--- a/resources/kubernetes/customer-config.ts
+++ b/resources/kubernetes/customer-config.ts
@@ -16,15 +16,27 @@ export const customerConfigMap = new kubernetes.core.v1.ConfigMap(
     data: {
       CUSTOMERS: customers.apply(customers => {
         const customersWithDomain = customers.map(customer => {
-          if (customer.domain) {
-            return customer;
-          }
+          const domain = customer.domain
+            ? `${customer.domain}.`
+            : `${customer.ident.current}.${rootDomain}`;
 
-          const domain = `${customer.ident.current}.${rootDomain}`;
+          const hasCustomDomain = Boolean(customer.domain?.trim());
+
+          // TODO: Revise this logic once it is safe to do so (every customer is using non custom domains)
+          const debitorPortalDomain = hasCustomDomain
+            ? `debitor.${domain}`
+            : domain;
+          const creditorPortalDomain = hasCustomDomain
+            ? domain
+            : `kred.${domain}`;
+          const apiDomain = `api.${domain}`;
 
           return {
             ...customer,
             domain,
+            debitorPortalDomain,
+            creditorPortalDomain,
+            apiDomain,
           };
         });
         return JSON.stringify(customersWithDomain);

--- a/resources/kubernetes/customer-config.ts
+++ b/resources/kubernetes/customer-config.ts
@@ -16,9 +16,11 @@ export const customerConfigMap = new kubernetes.core.v1.ConfigMap(
     data: {
       CUSTOMERS: customers.apply(customers => {
         const customersWithDomain = customers.map(customer => {
+          const cleanRootDomain = rootDomain.slice(0, -1);
+
           const domain = customer.domain
-            ? `${customer.domain}.`
-            : `${customer.ident.current}.${rootDomain}`;
+            ? customer.domain
+            : `${customer.ident.current}.${cleanRootDomain}`;
 
           const hasCustomDomain = Boolean(customer.domain?.trim());
 

--- a/resources/kubernetes/portal-app/portal-domains.ts
+++ b/resources/kubernetes/portal-app/portal-domains.ts
@@ -3,18 +3,20 @@ import * as gcp from '@pulumi/gcp';
 import { customers } from '../../get-customers';
 import { provider as gcpProvider } from '../../google/provider';
 import { rootDomain } from '../../shared/config';
+import { ingressIpAddress, zone } from '../../shared/google/dns';
 import { provider } from '../../shared/kubernetes/provider';
 import { debitorPortalApp } from '../debitor-portal-app/debitor-portal-app';
 import { namespace } from '../namespace';
 import { portalApi } from '../portal-api/portal-api';
 import { portalApp } from './portal-app';
-import { ingressIpAddress, zone } from '../../shared/google/dns';
 
 customers.apply(customers =>
   customers.map(customer => {
+    const cleanRootDomain = rootDomain.slice(0, -1);
+
     const domain = customer.domain
-      ? `${customer.domain}.`
-      : `${customer.ident.current}.${rootDomain}`;
+      ? customer.domain
+      : `${customer.ident.current}.${cleanRootDomain}`;
 
     const hasCustomDomain = Boolean(customer.domain?.trim());
 

--- a/resources/kubernetes/portal-app/portal-domains.ts
+++ b/resources/kubernetes/portal-app/portal-domains.ts
@@ -3,12 +3,12 @@ import * as gcp from '@pulumi/gcp';
 import { customers } from '../../get-customers';
 import { provider as gcpProvider } from '../../google/provider';
 import { rootDomain } from '../../shared/config';
+import { ingressIpAddress, zone } from '../../shared/google/dns';
 import { provider } from '../../shared/kubernetes/provider';
 import { debitorPortalApp } from '../debitor-portal-app/debitor-portal-app';
 import { namespace } from '../namespace';
 import { portalApi } from '../portal-api/portal-api';
 import { portalApp } from './portal-app';
-import { ingressIpAddress, zone } from '../../shared/google/dns';
 
 customers.apply(customers =>
   customers.map(customer => {

--- a/resources/kubernetes/portal-app/portal-domains.ts
+++ b/resources/kubernetes/portal-app/portal-domains.ts
@@ -3,20 +3,18 @@ import * as gcp from '@pulumi/gcp';
 import { customers } from '../../get-customers';
 import { provider as gcpProvider } from '../../google/provider';
 import { rootDomain } from '../../shared/config';
-import { ingressIpAddress, zone } from '../../shared/google/dns';
 import { provider } from '../../shared/kubernetes/provider';
 import { debitorPortalApp } from '../debitor-portal-app/debitor-portal-app';
 import { namespace } from '../namespace';
 import { portalApi } from '../portal-api/portal-api';
 import { portalApp } from './portal-app';
+import { ingressIpAddress, zone } from '../../shared/google/dns';
 
 customers.apply(customers =>
   customers.map(customer => {
-    const cleanRootDomain = rootDomain.slice(0, -1);
-
     const domain = customer.domain
-      ? customer.domain
-      : `${customer.ident.current}.${cleanRootDomain}`;
+      ? `${customer.domain}.`
+      : `${customer.ident.current}.${rootDomain}`;
 
     const hasCustomDomain = Boolean(customer.domain?.trim());
 

--- a/resources/kubernetes/portal-app/portal-domains.ts
+++ b/resources/kubernetes/portal-app/portal-domains.ts
@@ -3,12 +3,12 @@ import * as gcp from '@pulumi/gcp';
 import { customers } from '../../get-customers';
 import { provider as gcpProvider } from '../../google/provider';
 import { rootDomain } from '../../shared/config';
-import { ingressIpAddress, zone } from '../../shared/google/dns';
 import { provider } from '../../shared/kubernetes/provider';
 import { debitorPortalApp } from '../debitor-portal-app/debitor-portal-app';
 import { namespace } from '../namespace';
 import { portalApi } from '../portal-api/portal-api';
 import { portalApp } from './portal-app';
+import { ingressIpAddress, zone } from '../../shared/google/dns';
 
 customers.apply(customers =>
   customers.map(customer => {


### PR DESCRIPTION
The domain field in the customer config map is consumed by the applications and used for things like communication between services. Therefore it is useful to populate this field with appropriate values.