### PR TITLE
refactor: move debitor portal database credentials to ESC

### DIFF
--- a/resources/kubernetes/debitor-portal-app/debitor-portal-credentials.ts
+++ b/resources/kubernetes/debitor-portal-app/debitor-portal-credentials.ts
@@ -5,8 +5,8 @@ import { namespace } from '../namespace';
 
 const config = new pulumi.Config('debitor-portal-app');
 
-const portalUsername = config.requireSecret('portalUsername');
-const portalPassword = config.requireSecret('portalPassword');
+const user = config.requireSecret('database-user');
+const password = config.requireSecret('database-password');
 
 export const debitorPortalCredentials = new k8s.core.v1.Secret(
   'debitor-portal-database-credentials',
@@ -16,8 +16,8 @@ export const debitorPortalCredentials = new k8s.core.v1.Secret(
       namespace: namespace.metadata.name,
     },
     stringData: {
-      PORTAL_USERNAME: portalUsername,
-      PORTAL_PASSWORD: portalPassword,
+      PORTAL_USERNAME: user,
+      PORTAL_PASSWORD: password,
     },
   },
   { provider },


### PR DESCRIPTION
I think this is more secret. Both username and password should be secrets to minimise attack surface. This is a public repo, after all.