### PR TITLE
revert: de-bump portal app version

### DIFF
--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -20,7 +20,7 @@ config:
   portal-api:log-level: debug
   portal-api:tag: main-cc677a8
   portal-app:domain: creditor.fpx.no.
-  portal-app:tag: main-10ff28c
+  portal-app:tag: main-13e8237
   pulumi:disable-default-providers:
     - '*'
   registration-app:domain: reg.fpx.no.


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c61d0ba5-3dce-4576-a0a6-df8cf38459a5)
app did not look correct on login page, reverting version