### PR TITLE
fix: set up spec rules correctly

### DIFF
--- a/resources/kubernetes/portal-app/portal-domains.ts
+++ b/resources/kubernetes/portal-app/portal-domains.ts
@@ -62,6 +62,80 @@ customers.apply((customers) => {
       );
     }
 
+    const rules = [
+      {
+        host: creditorPortalDomain.slice(0, -1),
+        http: {
+          paths: [
+            {
+              path: "/",
+              pathType: "Prefix",
+              backend: {
+                service: {
+                  name: portalApp.service.metadata.name,
+                  port: { number: portalApp.port },
+                },
+              },
+            },
+          ],
+        },
+      },
+      {
+        host: apiDomain.slice(0, -1),
+        http: {
+          paths: [
+            {
+              path: "/",
+              pathType: "Prefix",
+              backend: {
+                service: {
+                  name: portalApi.service.metadata.name,
+                  port: { number: portalApi.port },
+                },
+              },
+            },
+          ],
+        },
+      },
+      {
+        host: debitorPortalDomain.slice(0, -1),
+        http: {
+          paths: [
+            {
+              path: "/",
+              pathType: "Prefix",
+              backend: {
+                service: {
+                  name: debitorPortalApp.service.metadata.name,
+                  port: { number: debitorPortalApp.port },
+                },
+              },
+            },
+          ],
+        },
+      },
+    ];
+
+    if (hasCustomDomain) {
+      rules.push({
+        host: restApiDomain.slice(0, -1),
+        http: {
+          paths: [
+            {
+              path: "/",
+              pathType: "Prefix",
+              backend: {
+                service: {
+                  name: restApiApp.service.metadata.name,
+                  port: { number: restApiApp.port },
+                },
+              },
+            },
+          ],
+        },
+      });
+    }
+
     new k8s.networking.v1.Ingress(
       `${customer.ident.current}-ingress`,
       {
@@ -79,78 +153,7 @@ customers.apply((customers) => {
           },
         },
         spec: {
-          rules: [
-            {
-              host: creditorPortalDomain.slice(0, -1),
-              http: {
-                paths: [
-                  {
-                    path: "/",
-                    pathType: "Prefix",
-                    backend: {
-                      service: {
-                        name: portalApp.service.metadata.name,
-                        port: { number: portalApp.port },
-                      },
-                    },
-                  },
-                ],
-              },
-            },
-            {
-              host: apiDomain.slice(0, -1),
-              http: {
-                paths: [
-                  {
-                    path: "/",
-                    pathType: "Prefix",
-                    backend: {
-                      service: {
-                        name: portalApi.service.metadata.name,
-                        port: { number: portalApi.port },
-                      },
-                    },
-                  },
-                ],
-              },
-            },
-            {
-              host: debitorPortalDomain.slice(0, -1),
-              http: {
-                paths: [
-                  {
-                    path: "/",
-                    pathType: "Prefix",
-                    backend: {
-                      service: {
-                        name: debitorPortalApp.service.metadata.name,
-                        port: { number: debitorPortalApp.port },
-                      },
-                    },
-                  },
-                ],
-              },
-            },
-            hasCustomDomain
-              ? {
-                  host: restApiDomain.slice(0, -1),
-                  http: {
-                    paths: [
-                      {
-                        path: "/",
-                        pathType: "Prefix",
-                        backend: {
-                          service: {
-                            name: restApiApp.service.metadata.name,
-                            port: { number: restApiApp.port },
-                          },
-                        },
-                      },
-                    ],
-                  },
-                }
-              : {},
-          ],
+          rules,
         },
       },
       { provider },


### PR DESCRIPTION
It's possible that the empty rule `{}` caused some kind of bug. Our ingress is broken at the moment.