### PR TITLE
fix: use stringData for secrets to ensure valid UTF-8 env vars

### DIFF
--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -16,9 +16,9 @@ config:
   onboarding-app:domain: onboarding.fpx.no.
   onboarding-app:tag: main-93d5d97
   portal-api:auth-sign-secret:
-    secure: AAABAGNx2AH3V5QmwfBOzUjXpZ5OBSBNbdL+QgB0I5a37lHMMcsUVz+vl4snxg+thegbVzM0plRWgiALUupL88JvEkrLB4zodEhXFD4S9xNzOSZXkbUaXSroU/ZOoAhZ
+    secure: AAABANHytn22PWHK7781DdVTMvmwKxUbS68uQLOglqkCtz1GkxhZt1GZMwNJ+SCTt+l7A2Mb3noDfEzpmU1+UL2MOVvl9q4kj0MrEtkjUebtwUaQkMeBe9q2d2sNlANx
   portal-api:cookie-secret:
-    secure: AAABADy2iSkKwef0IiFd0IDXze14jO0VtDr6oM53MXgdadia3pK7wN0U2AArLuQ0GooGBzS6GxGuvCPSgZV2MdfaumwMzdzpoe1OHNN9jP5NGQaJP/RpQRPhlx4r3YnH
+    secure: AAABAAAskVEQvCaiI0w6VvWWijFV2dRZVGCtvgHYsnL0CJ3feRklKohg/e48AV4O6GBo7BK16jepyWVw7T4C7ZAid4HEDlnr14KmMrUH23j1sNTWzSNCcdH1VR6aTKyp
   portal-api:domain: api.fpx.no.
   portal-api:log-level: debug
   portal-api:tag: main-f967d06

--- a/resources/kubernetes/api/api.ts
+++ b/resources/kubernetes/api/api.ts
@@ -44,10 +44,8 @@ export const apiEnvSecrets = new kubernetes.core.v1.Secret(
 			name: "api-env-secrets",
 			namespace: namespace.metadata.name,
 		},
-		data: {
-			COOKIE_SECRET: cookieSecret,
-		},
 		stringData: {
+			COOKIE_SECRET: cookieSecret,
 			DEBITOR_PORTAL_APP_USERNAME: user,
 			DEBITOR_PORTAL_APP_PASSWORD: password,
 			DEBITOR_PORTAL_APP_API_KEY: debitorPortalAppApiKey,

--- a/resources/kubernetes/portal-api/portal-api.ts
+++ b/resources/kubernetes/portal-api/portal-api.ts
@@ -23,7 +23,7 @@ export const portalApiEnvSecrets = new kubernetes.core.v1.Secret(
 			name: "portal-api-env-secrets",
 			namespace: namespace.metadata.name,
 		},
-		data: {
+		stringData: {
 			COOKIE_SECRET: cookieSecret,
 			AUTH_SIGN_SECRET: authSignSecret,
 		},


### PR DESCRIPTION
## Summary
- Containerd/GKE started enforcing UTF-8 validation on env var values passed via gRPC, causing `CreateContainerError` on `api`, `portal-api`, and `portal-app-go` pods (down for 37h)
- Moved `COOKIE_SECRET` and `AUTH_SIGN_SECRET` from `data` to `stringData` in K8s Secret resources so the values are stored as plain strings rather than raw binary
- Regenerated both secrets as base64-encoded random strings (valid UTF-8)

## Test plan
- [x] Production already patched manually via `kubectl patch` — all pods confirmed running
- [ ] Run `pulumi preview` to verify no unexpected changes
- [ ] Merge and run `pulumi up` to align Pulumi state with the manual fix