### PR TITLE
feat: deploy portal-app-svelte with path-prefix routing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,53 @@
+# conf
+
+Pulumi infrastructure-as-code for the Flexisoft platform. Manages GKE (Google Kubernetes Engine), Kubernetes resources, GitHub configuration, and DNS/ingress.
+
+## What it manages
+
+- GKE cluster on Google Cloud Platform
+- Kubernetes namespaces (one per environment), deployments, ingresses, ConfigMaps
+- Caddy as reverse proxy with automatic SSL (ingress hostname: `ingress.fpx.no`)
+- GitHub repository secrets (NPM bot tokens)
+- Redis deployment for portal session storage
+- Customer domain DNS config (CNAME to `ingress.fpx.no` or A records)
+
+## Stack
+
+- Pulumi with TypeScript (`ts-node/esm`)
+- `@pulumi/gcp`, `@pulumi/kubernetes`, `@pulumi/github`
+- `@1password/sdk` for secrets
+- `@sanity/client` to pull customer config from Sanity
+
+## Prerequisites
+
+- [Pulumi CLI](https://www.pulumi.com/docs/get-started/install/)
+- Google Cloud SDK (`gcloud auth login`)
+- `kubectl`
+- Node.js + pnpm
+
+## Commands
+
+```sh
+pnpm install          # install dependencies
+pulumi preview        # preview infrastructure changes
+pulumi up             # apply infrastructure changes
+pnpm run lint:check   # run xo linter
+pnpm run format       # format with prettier
+```
+
+## Project structure
+
+```
+index.ts             # Pulumi entrypoint
+resources/
+  kubernetes/        # Kubernetes resources (deployments, ingresses, etc.)
+  google/            # GCP-specific resources
+  github/            # GitHub secret management
+  shared/            # Shared utilities
+  config.ts          # Pulumi stack config helpers
+Pulumi.prod.yaml     # Production stack config
+```
+
+## Custom domain setup
+
+Customers should add a CNAME pointing their subdomains to `ingress.fpx.no`. Root domains must use A records (CNAME on root is not allowed by DNS spec).

--- a/index.ts
+++ b/index.ts
@@ -8,6 +8,8 @@ import "./resources/kubernetes/portal-api/redis.js";
 import "./resources/kubernetes/portal-api/portal-api.js";
 import "./resources/kubernetes/portal-app/portal-app.js";
 import "./resources/kubernetes/portal-app/github-actions-secrets.js";
+import "./resources/kubernetes/tenants-config-map.js";
+import "./resources/kubernetes/portal-app-svelte/portal-app-svelte.js";
 import "./resources/kubernetes/altinn-auth-app/altinn-auth-app.js";
 import "./resources/google/customer-dns.js";
 import "./resources/kubernetes/ingress.js";

--- a/resources/kubernetes/ingress.ts
+++ b/resources/kubernetes/ingress.ts
@@ -11,6 +11,11 @@ import {
 	portalAppGoPort,
 	goAppPaths,
 } from "./portal-app/portal-app.js";
+import {
+	portalAppSvelteService,
+	portalAppSveltePort,
+	svelteAppPaths,
+} from "./portal-app-svelte/portal-app-svelte.js";
 import { onboardingApp } from "./onboarding/onboarding-app.js";
 import { restApiApp } from "./api/api.js";
 
@@ -23,7 +28,22 @@ customers.apply((customers) => {
 				host: customer.creditorPortalDomain,
 				http: {
 					paths: [
-						// Routes for the new Go app (specific paths)
+						// Routes for the SvelteKit rewrite (specific paths).
+						// Populated incrementally as pages migrate; see
+						// `svelteAppPaths` in portal-app-svelte.ts.
+						...svelteAppPaths.map((path) => ({
+							path,
+							pathType: "Prefix" as const,
+							backend: {
+								service: {
+									name: portalAppSvelteService.metadata.name,
+									port: {
+										number: portalAppSveltePort,
+									},
+								},
+							},
+						})),
+						// Routes for the (deprecated) Go app (specific paths).
 						...goAppPaths.map((path) => ({
 							path,
 							pathType: "Prefix" as const,

--- a/resources/kubernetes/portal-app-svelte/portal-app-svelte.ts
+++ b/resources/kubernetes/portal-app-svelte/portal-app-svelte.ts
@@ -1,0 +1,123 @@
+import * as k8s from "@pulumi/kubernetes";
+import * as pulumi from "@pulumi/pulumi";
+import { interpolate } from "@pulumi/pulumi";
+import { customers } from "../../get-customers.js";
+import { artifactRepoUrl } from "../../shared/google/artifact-registry.js";
+import { provider as kubernetesProvider } from "../../shared/kubernetes/provider.js";
+import { namespace } from "../namespace.js";
+import {
+	tenantsConfigMap,
+	tenantsMountPath,
+} from "../tenants-config-map.js";
+
+const config = new pulumi.Config("portal-app-svelte");
+const environment = pulumi.getStack();
+
+const labels = { app: "portal-app-svelte", environment };
+
+export const portalAppSveltePort = 3000;
+
+export const portalAppSvelteDeployment = new k8s.apps.v1.Deployment(
+	"portal-app-svelte",
+	{
+		metadata: {
+			name: "portal-app-svelte",
+			namespace: namespace.metadata.name,
+			labels: { environment },
+			annotations: {
+				"pulumi.com/skipAwait": "true",
+			},
+		},
+		spec: {
+			replicas: 1,
+			selector: { matchLabels: labels },
+			template: {
+				metadata: { labels },
+				spec: {
+					containers: [
+						{
+							name: "portal-app-svelte",
+							image: interpolate`${artifactRepoUrl}/portal-app-svelte:${config.require("tag")}`,
+							imagePullPolicy: "IfNotPresent",
+							ports: [{ containerPort: portalAppSveltePort }],
+							env: [
+								{ name: "PORT", value: String(portalAppSveltePort) },
+								{ name: "LOG_LEVEL", value: config.get("log-level") ?? "info" },
+								{ name: "NODE_ENV", value: "production" },
+								// New tenant source. Loader prefers this over CUSTOMERS.
+								{ name: "TENANTS_DIR", value: tenantsMountPath },
+								// Legacy fallback. Kept during the transition per
+								// MIGRATION.md so this deployment also works if the
+								// ConfigMap volume mount ever fails to materialize.
+								{
+									name: "CUSTOMERS",
+									value: customers.apply((cs) =>
+										JSON.stringify(
+											cs.filter((c) => c.creditorPortalEnabled),
+										),
+									),
+								},
+							],
+							volumeMounts: [
+								{
+									name: "tenants",
+									mountPath: tenantsMountPath,
+									readOnly: true,
+								},
+							],
+							resources: {
+								requests: { cpu: "250m", memory: "512Mi" },
+								limits: { cpu: "250m", memory: "512Mi" },
+							},
+							readinessProbe: {
+								httpGet: {
+									path: "/health",
+									port: portalAppSveltePort,
+									scheme: "HTTP",
+								},
+								initialDelaySeconds: 60,
+								periodSeconds: 10,
+								failureThreshold: 5,
+							},
+						},
+					],
+					volumes: [
+						{
+							name: "tenants",
+							configMap: {
+								name: tenantsConfigMap.metadata.name,
+							},
+						},
+					],
+				},
+			},
+		},
+	},
+	{ provider: kubernetesProvider, deleteBeforeReplace: true },
+);
+
+export const portalAppSvelteService = new k8s.core.v1.Service(
+	"portal-app-svelte",
+	{
+		metadata: {
+			name: "portal-app-svelte",
+			namespace: namespace.metadata.name,
+			labels: { environment },
+		},
+		spec: {
+			ports: [{ port: portalAppSveltePort }],
+			selector: labels,
+		},
+	},
+	{ provider: kubernetesProvider, deleteBeforeReplace: true },
+);
+
+// Path prefixes the SvelteKit app owns on the creditor portal domain.
+// Routed in `ingress.ts` ahead of the React catch-all, identical pattern
+// to `goAppPaths` in `portal-app/portal-app.ts`. Add a prefix here as
+// each page is migrated from React/Go to SvelteKit; remove the matching
+// entry from `goAppPaths` if it overlaps.
+//
+// Empty at Phase 0 — the deployment is reachable in-cluster but takes
+// no public traffic until the first page is migrated.
+export const svelteAppPaths: string[] = [];

--- a/resources/kubernetes/portal-app-svelte/portal-app-svelte.ts
+++ b/resources/kubernetes/portal-app-svelte/portal-app-svelte.ts
@@ -5,10 +5,7 @@ import { customers } from "../../get-customers.js";
 import { artifactRepoUrl } from "../../shared/google/artifact-registry.js";
 import { provider as kubernetesProvider } from "../../shared/kubernetes/provider.js";
 import { namespace } from "../namespace.js";
-import {
-	tenantsConfigMap,
-	tenantsMountPath,
-} from "../tenants-config-map.js";
+import { tenantsConfigMap, tenantsMountPath } from "../tenants-config-map.js";
 
 const config = new pulumi.Config("portal-app-svelte");
 const environment = pulumi.getStack();
@@ -52,9 +49,7 @@ export const portalAppSvelteDeployment = new k8s.apps.v1.Deployment(
 								{
 									name: "CUSTOMERS",
 									value: customers.apply((cs) =>
-										JSON.stringify(
-											cs.filter((c) => c.creditorPortalEnabled),
-										),
+										JSON.stringify(cs.filter((c) => c.creditorPortalEnabled)),
 									),
 								},
 							],

--- a/resources/kubernetes/tenants-config-map.ts
+++ b/resources/kubernetes/tenants-config-map.ts
@@ -1,5 +1,5 @@
 import * as kubernetes from "@pulumi/kubernetes";
-import * as pulumi from "@pulumi/pulumi";
+import type * as pulumi from "@pulumi/pulumi";
 import { customers } from "../get-customers.js";
 import { provider as kubernetesProvider } from "../shared/kubernetes/provider.js";
 import { namespace } from "./namespace.js";
@@ -37,6 +37,7 @@ export const tenantsConfigMap = new kubernetes.core.v1.ConfigMap(
 			for (const c of cs) {
 				data[`${c.ident.current}.json`] = JSON.stringify(c);
 			}
+
 			return data;
 		}),
 	},

--- a/resources/kubernetes/tenants-config-map.ts
+++ b/resources/kubernetes/tenants-config-map.ts
@@ -1,0 +1,48 @@
+import * as kubernetes from "@pulumi/kubernetes";
+import * as pulumi from "@pulumi/pulumi";
+import { customers } from "../get-customers.js";
+import { provider as kubernetesProvider } from "../shared/kubernetes/provider.js";
+import { namespace } from "./namespace.js";
+
+/**
+ * Per-tenant ConfigMap consumed by apps that have migrated off the
+ * legacy `CUSTOMERS` env var (see `MIGRATION.md` § "Tenant
+ * configuration").
+ *
+ * One file per tenant, plus an `_index.json` listing idents. Apps
+ * mount the ConfigMap as a volume and read from
+ * `/etc/flexisoft/tenants/`. Files starting with `_` are metadata
+ * for tooling, not tenant data, and are skipped by the loaders.
+ *
+ * NOTE: the data shape matches today's `CUSTOMERS` element exactly,
+ * which means secret-bearing fields like `merchantId` and
+ * `merchantApiKey` ride along. That posture is unchanged from
+ * what's already in cluster ConfigMaps today; lifting those into
+ * a separate Secret is tracked as a follow-up.
+ */
+export const tenantsConfigMap = new kubernetes.core.v1.ConfigMap(
+	"tenants",
+	{
+		metadata: {
+			name: "tenants",
+			namespace: namespace.metadata.name,
+			annotations: {
+				"pulumi.com/skipAwait": "true",
+			},
+		},
+		data: customers.apply((cs) => {
+			const data: Record<string, pulumi.Input<string>> = {
+				"_index.json": JSON.stringify(cs.map((c) => c.ident.current)),
+			};
+			for (const c of cs) {
+				data[`${c.ident.current}.json`] = JSON.stringify(c);
+			}
+			return data;
+		}),
+	},
+	{ provider: kubernetesProvider },
+);
+
+/** Mount path used by every consuming app. Keep this in sync with the
+ * `TENANTS_DIR` defaults in app source. */
+export const tenantsMountPath = "/etc/flexisoft/tenants";


### PR DESCRIPTION
## Summary

Runs the new SvelteKit portal app alongside `portal-app` (React) and
`portal-app-go` (Go) on the **same** `creditorPortalDomain`. Traffic
splits exactly like `goAppPaths` does today: a curated list of path
prefixes routes to the SvelteKit service, everything else falls
through to the React app.

## What's in the change

| File | Why |
|---|---|
| `resources/kubernetes/tenants-config-map.ts` | New cluster-wide `tenants` ConfigMap. One `<ident>.json` per customer plus `_index.json`. Mounted by apps using the new `TENANTS_DIR` loader. |
| `resources/kubernetes/portal-app-svelte/portal-app-svelte.ts` | Deployment + Service for the SvelteKit app. Mounts the tenants ConfigMap at `/etc/flexisoft/tenants` and *also* injects the legacy `CUSTOMERS` env var as a transition fallback. Exports `svelteAppPaths`. |
| `resources/kubernetes/ingress.ts` | Slots `svelteAppPaths` into the per-customer creditor-portal rule, ahead of `goAppPaths` and the React catch-all. |
| `index.ts` | Registers the two new modules. |

`svelteAppPaths` starts **empty**. The deployment is reachable
in-cluster but takes no public traffic until the first page migrates;
at that point a path goes in here and (if it overlaps) the matching
entry comes out of `goAppPaths`.

## Required before `pulumi up`

- `portal-app-svelte:tag` (CI-built image tag).
- `portal-app-svelte:log-level` (optional, defaults to `info`).

A `portal-app-svelte` image must exist in the artifact registry under
`${artifactRepoUrl}/portal-app-svelte:<tag>` before this deploys
successfully. The deployment will go unhealthy until that's true.

## Test plan

- [ ] `pulumi preview` — verify the new ConfigMap, Deployment, Service
      show up as `+` and no other resources are unexpectedly modified
- [ ] After CI publishes the first image and `portal-app-svelte:tag`
      is set, `pulumi up` and verify the pod becomes ready (probes
      `/health`, which 500s until tenants load and then 200s)
- [ ] `kubectl exec` into the pod and confirm
      `/etc/flexisoft/tenants/_index.json` lists every customer
- [ ] Hit a known SvelteKit-served path (once added to
      `svelteAppPaths`) on a customer's `creditorPortalDomain` and
      confirm it routes to the SvelteKit pod

## Known follow-ups

- `merchantId` / `merchantApiKey` ride along in the tenants ConfigMap
  (same posture as today's `CUSTOMERS` env). Extract into a per-tenant
  Secret in a later PR.
- `DeploymentComponent` doesn't support volume mounts; this
  deployment bypasses it like `portal-app.ts` does. Adding volume
  support to the shared component is a separate cleanup.
- The legacy `CUSTOMERS` env mount in `portal-app-svelte` gets dropped
  once we've verified the ConfigMap path in production for one
  observation window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)