### PR TITLE
feat: provision GitHub Actions secrets for portal-app-svelte

### DIFF
--- a/resources/repository-access.ts
+++ b/resources/repository-access.ts
@@ -19,6 +19,7 @@ const repositories = [
 	"api",
 	"portal-api",
 	"portal-app",
+	"portal-app-svelte",
 	"debitor-portal-app",
 	"registration-app",
 	"onboarding-app",

--- a/resources/shared/github/container-registry-secret.ts
+++ b/resources/shared/github/container-registry-secret.ts
@@ -6,6 +6,7 @@ const repositoriesWithArtifacts = [
 	"api",
 	"portal-api",
 	"portal-app",
+	"portal-app-svelte",
 	"debitor-portal-app",
 	"registration-app",
 	"onboarding-app",


### PR DESCRIPTION
## Summary

Adds `portal-app-svelte` to the two arrays that drive CI secret
provisioning across the org. Unblocks the build/deploy workflow on
`flexisoftorg/portal-app-svelte` — without these the workflow can't
authenticate to GCP or know where to push images.

After `pulumi up`, the following `ActionsSecret`s land on the
`portal-app-svelte` repo:

| Secret | Source |
|---|---|
| `GOOGLE_PROJECT_ID` | `GitHubAccess` in `repository-access.ts` |
| `GOOGLE_WORKLOAD_IDENTITY_PROVIDER` | same |
| `GOOGLE_SERVICE_ACCOUNT` | same (per-repo SA, isolated from other apps) |
| `CONTAINER_REGISTRY` | `shared/github/container-registry-secret.ts` |

`BOT_GITHUB_TOKEN` already lands via the org-wide `bot-secret.ts`
sweep — no change needed there.

Also creates:

- A new GCP service account `prod-portal-app-svelte-github`
- `workloadIdentityUser` + `serviceAccountTokenCreator` bindings
  scoped to `flexisoftorg/portal-app-svelte`
- `artifactregistry.writer` on the shared artifact registry for that
  service account

## Test plan

- [ ] `pulumi preview` shows only additions: 1 service account, 4
      `ActionsSecret`s, 2 `IAMMember`s, 1 `RepositoryIamMember`. No
      changes to other repos' secrets.
- [ ] After `pulumi up`, confirm in the GitHub UI on
      `flexisoftorg/portal-app-svelte` → Settings → Secrets that all
      four secrets are present and non-empty.
- [ ] Workflow run on the repo successfully authenticates to GCP and
      pushes an image to
      `${artifactRepoUrl}/portal-app-svelte:<tag>`.

## Sequencing

This is a prerequisite for the deployment PR
[#1007](https://github.com/flexisoftorg/conf/pull/1007). Merge order:
this one first → CI publishes the first image → set
`portal-app-svelte:tag` in `Pulumi.prod.yaml` → merge #1007.

🤖 Generated with [Claude Code](https://claude.com/claude-code)