### PR TITLE
Mount tenants ConfigMap into the rest API deployment

### DIFF
--- a/resources/components/deployment.ts
+++ b/resources/components/deployment.ts
@@ -57,9 +57,7 @@ export type AppComponentArgs = {
 	/**
 	 * Pod volumes (e.g. a ConfigMap to mount). Pair with `volumeMounts`.
 	 */
-	volumes?: pulumi.Input<
-		Array<pulumi.Input<k8s.types.input.core.v1.Volume>>
-	>;
+	volumes?: pulumi.Input<Array<pulumi.Input<k8s.types.input.core.v1.Volume>>>;
 
 	/**
 	 * Container volume mounts. Pair with `volumes`.

--- a/resources/components/deployment.ts
+++ b/resources/components/deployment.ts
@@ -55,6 +55,20 @@ export type AppComponentArgs = {
 	namespace?: pulumi.Input<string>;
 
 	/**
+	 * Pod volumes (e.g. a ConfigMap to mount). Pair with `volumeMounts`.
+	 */
+	volumes?: pulumi.Input<
+		Array<pulumi.Input<k8s.types.input.core.v1.Volume>>
+	>;
+
+	/**
+	 * Container volume mounts. Pair with `volumes`.
+	 */
+	volumeMounts?: pulumi.Input<
+		Array<pulumi.Input<k8s.types.input.core.v1.VolumeMount>>
+	>;
+
+	/**
 	 * If applied, default probe will be overwritten
 	 */
 	readinessProbe?: pulumi.Input<k8s.types.input.core.v1.Probe>;
@@ -86,6 +100,8 @@ export class DeploymentComponent extends pulumi.ComponentResource {
 			environment = pulumi.getStack(),
 			namespace,
 			resources,
+			volumes = [],
+			volumeMounts = [],
 		} = args;
 
 		this.port = pulumi.output(port);
@@ -146,8 +162,10 @@ export class DeploymentComponent extends pulumi.ComponentResource {
 									]),
 									resources,
 									readinessProbe,
+									volumeMounts,
 								},
 							],
+							volumes,
 						},
 					},
 				},

--- a/resources/kubernetes/api/api.ts
+++ b/resources/kubernetes/api/api.ts
@@ -10,6 +10,7 @@ import { registrationAppSanityCredentials } from "../registration-app/sanity-cre
 import { redis } from "../portal-api/redis.js";
 import { customers } from "../../get-customers.js";
 import { rootDomain } from "../../shared/config.js";
+import { tenantsConfigMap, tenantsMountPath } from "../tenants-config-map.js";
 
 const config = new pulumi.Config("api");
 
@@ -81,6 +82,29 @@ export const restApiApp = new DeploymentComponent(
 			{
 				name: "ALLOWED_ORIGINS",
 				value: allowedOrigins,
+			},
+			// Tenant source for the in-memory store. The loader reads every
+			// `*.json` under this dir; the volume mount below populates it
+			// from the shared `tenants` ConfigMap. go-api exits on an empty
+			// store, so this must resolve to a non-empty directory.
+			{
+				name: "TENANTS_DIR",
+				value: tenantsMountPath,
+			},
+		],
+		volumeMounts: [
+			{
+				name: "tenants",
+				mountPath: tenantsMountPath,
+				readOnly: true,
+			},
+		],
+		volumes: [
+			{
+				name: "tenants",
+				configMap: {
+					name: tenantsConfigMap.metadata.name,
+				},
 			},
 		],
 		port: 8000,


### PR DESCRIPTION
The rest API deployment loads its tenant store from a directory of per-tenant JSON files, but it was deployed without one — so the store was empty and every authenticated request returned an "unknown tenant" 400.

## Changes

- Mount the shared `tenants` ConfigMap into the API deployment and set `TENANTS_DIR` to its mount path, matching how portal-app-svelte already consumes it.
- Add optional `volumes` / `volumeMounts` to the shared `DeploymentComponent` (additive — existing callers are unaffected) so the API can mount config without dropping down to a raw Deployment.

## Deploy ordering

The API image now exits at startup if the tenant store ends up empty. Apply this together with that image so the ConfigMap is mounted before the new binary runs; otherwise the pod will crash-loop on an empty store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)