### PR TITLE
fix: gate auth-app ingress rule on authAppEnabled

### DIFF
--- a/resources/kubernetes/ingress.ts
+++ b/resources/kubernetes/ingress.ts
@@ -163,25 +163,32 @@ customers.apply((customers) => {
 			});
 		}
 
-		rules.push({
-			host: customer.authAppDomain,
-			http: {
-				paths: [
-					{
-						path: "/",
-						pathType: "Prefix",
-						backend: {
-							service: {
-								name: authAppService.metadata.name,
-								port: {
-									number: authAppPort,
+		// Gate on the same flag as the auth-app DNS record (customer-dns.ts) and
+		// the rest-api rule above. Adding an `auth.<domain>` host for a customer
+		// with the feature disabled points Caddy at a name with no DNS record, so
+		// its ACME challenge for that host fails — and enough such failures
+		// rate-limit certificate issuance for the *enabled* auth hosts too.
+		if (customer.authAppEnabled) {
+			rules.push({
+				host: customer.authAppDomain,
+				http: {
+					paths: [
+						{
+							path: "/",
+							pathType: "Prefix",
+							backend: {
+								service: {
+									name: authAppService.metadata.name,
+									port: {
+										number: authAppPort,
+									},
 								},
 							},
 						},
-					},
-				],
-			},
-		});
+					],
+				},
+			});
+		}
 
 		new k8s.networking.v1.Ingress(
 			`${customer.ident.current}-ingress`,


### PR DESCRIPTION
## Summary

Only add the `auth.<domain>` ingress host for customers that have the auth-app enabled, matching the auth-app DNS record in `customer-dns.ts` (added in #1036) and the rest-api rule above it.

## Why

Previously the auth-app rule was pushed for **every** customer (#1034). But there is only a DNS record for `auth.<domain>` when the feature is enabled. For a disabled customer, Caddy still tries to obtain a certificate for a host that has no DNS record, so the ACME challenge fails — and enough such failures rate-limit certificate issuance for the *enabled* auth hosts too.

Gating the ingress rule on `customer.authAppEnabled` keeps ingress, DNS, and cert issuance consistent.

## Testing

- `pnpm run lint:check` passes
- `auth.demo.fpx.no` (an enabled customer) resolves and serves: `http → 308 → https`, `/health → 200`

🤖 Generated with [Claude Code](https://claude.com/claude-code)