### PR TITLE
Set APP_ENV=production on the go-api deployment

### DIFF
--- a/resources/kubernetes/api/api.ts
+++ b/resources/kubernetes/api/api.ts
@@ -71,6 +71,14 @@ export const restApiApp = new DeploymentComponent(
 			},
 		],
 		env: [
+			// Without this the app defaults to development mode, which keeps the
+			// dev-tenant fallback active and makes the MCP endpoint advertise the
+			// localhost OAuth defaults instead of deriving the auth server per
+			// tenant. Matches the auth-app deployment.
+			{
+				name: "APP_ENV",
+				value: "production",
+			},
 			{
 				name: "REDIS_URL",
 				value: interpolate`${redis.service.metadata.name}.${redis.service.metadata.namespace}.svc.cluster.local:6379`,


### PR DESCRIPTION
## Problem

After merging the per-tenant MCP discovery change (flexisoftorg/api#90), the MCP endpoint still advertised the localhost OAuth defaults and claude.ai connector registration kept failing. The api pod logs revealed why:

```
WARN JWT_PUBLIC_KEY_URL is not set; access tokens cannot be verified. Acceptable for development only.
     config.go:74 (*Config).Validate
```

That warning only fires from the **development** branch of `Validate`. The api deployment never sets `APP_ENV`, and it defaults to `development` — so go-api runs in **development mode in production**. Consequences:

- The per-tenant MCP metadata / JWKS derivation is gated on `!IsDevelopment()`, so it stays off and the endpoint keeps advertising `AUTH_SERVER_URL`'s localhost default.
- The `DevTenant` fallback stays active, so unmatched hosts resolve to the `demo` tenant.

## Change

Set `APP_ENV: "production"` on the api deployment, matching the auth-app deployment (which already sets it).

## Deploy ordering

Must go out with (or after) an api image that treats `JWT_PUBLIC_KEY_URL` as optional (i.e. includes flexisoftorg/api#90). Older images call `errors` out of `Validate` when `APP_ENV=production` and `JWT_PUBLIC_KEY_URL` is unset, so they would crash-loop. Bump `api:tag` to a #90 image in the same `pulumi up`.

## Verify after apply

```sh
curl -s https://rest.demo.fpx.no/.well-known/oauth-protected-resource | jq .
# → resource: https://rest.demo.fpx.no, authorization_servers: ["https://auth.demo.fpx.no"]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)