### PR TITLE
upgrade @pulumi/github to 6.14.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 	"dependencies": {
 		"@1password/sdk": "^0.3.1",
 		"@pulumi/gcp": "^9.0.0",
-		"@pulumi/github": "^6.7.2",
+		"@pulumi/github": "^6.14.1",
 		"@pulumi/google-native": "^0.32.0",
 		"@pulumi/kubernetes": "^4.23.0",
 		"@pulumi/pulumi": "^3.173.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^9.0.0
         version: 9.6.0(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.9.3))(typescript@5.9.3)
       '@pulumi/github':
-        specifier: ^6.7.2
-        version: 6.9.1(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.9.3))(typescript@5.9.3)
+        specifier: ^6.14.1
+        version: 6.14.1(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.9.3))(typescript@5.9.3)
       '@pulumi/google-native':
         specifier: ^0.32.0
         version: 0.32.0(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.9.3))(typescript@5.9.3)
@@ -386,8 +386,8 @@ packages:
   '@pulumi/gcp@9.6.0':
     resolution: {integrity: sha512-kEKrPG7WwstD5JWfQW2kHIBaeR1/QZw8rioFyoh5DfrlZmej02CQ/9TVypaOlgQF4+m4iBwEIZeglv0/WS4mYg==}
 
-  '@pulumi/github@6.9.1':
-    resolution: {integrity: sha512-B7FcceruXfMClws4poIyUfJoy2dqcdhi8P5+ahfArIeaDjFDlcRNU9SZbfFRbkdoXflMJi+AI3rWabyvqS2+YQ==}
+  '@pulumi/github@6.14.1':
+    resolution: {integrity: sha512-1murHMQUyCattdVr/bI0A/QhUitWX0NO31PUvNfc53khqvWwIg3T9sCowrwkf4ui4Q2bWPoHi89wuTzVOHWp4g==}
 
   '@pulumi/google-native@0.32.0':
     resolution: {integrity: sha512-7PJrCGHhmN/WnscNoImQtJPd1y817F/678KcgT8JhtTo4Af5enFpKXbQP4owoA9ngoJ4s+0lopBJHDbQi528Zw==}
@@ -3375,7 +3375,7 @@ snapshots:
       - ts-node
       - typescript
 
-  '@pulumi/github@6.9.1(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.9.3))(typescript@5.9.3)':
+  '@pulumi/github@6.14.1(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
       '@pulumi/pulumi': 3.210.0(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.9.3))(typescript@5.9.3)
     transitivePeerDependencies:


### PR DESCRIPTION
Unblocks CI applies.

A local `pulumi up` ran with nixpkgs' `pulumi-bin`, which bundles `pulumi-resource-github v6.14.1` and takes precedence over the version this project pins. That provider migrated all 60 `ActionsSecret` resources from state schema version 1 to 2.

CI then downloads the pinned 6.9.1, which fails on every apply:

```
State version 2 is greater than schema version 1 for resource github_actions_secret
```

The v2 migration restructured the data — it added `keyId`, `repositoryId`, `value`, `valueEncrypted` and `remoteUpdatedAt` — so reverting the marker alone would corrupt state. Matching the provider to what is already in state is the correct direction.

Scope is limited to `ActionsSecret`; gcp, kubernetes and google-native state is untouched, confirmed by diffing the pre-migration backup against current state.

The PR check exercises this: `pulumi preview` has to load the github provider against v2 state.