### PR TITLE
give elsa-gateway its own namespace

### DIFF
--- a/resources/kubernetes/elsa-gateway/elsa-gateway.ts
+++ b/resources/kubernetes/elsa-gateway/elsa-gateway.ts
@@ -5,8 +5,11 @@ import { environment } from "../../config.js";
 import { artifactRepoUrl } from "../../shared/google/artifact-registry.js";
 import { provider } from "../../shared/kubernetes/provider.js";
 import { GarageBucket } from "../garage/bucket.js";
-import { imagePullSecrets } from "../image-pull-secret.js";
-import { namespace } from "../namespace.js";
+import {
+	createImagePullSecrets,
+	imagePullSecrets,
+} from "../image-pull-secret.js";
+import { namespace } from "./namespace.js";
 
 /**
  * ELSA Gateway delivers claims to Skatteetaten's SIMS endpoint and collects
@@ -25,6 +28,8 @@ const config = new pulumi.Config(name);
 const certificateMountPath = "/etc/elsa-gateway";
 const proxyAddress = "127.0.0.1:1055";
 const tailscaleTag = "tag:elsa-gateway";
+
+createImagePullSecrets(namespace.metadata.name, `-${name}`);
 
 /** The virksomhetssertifikat SIMS authenticates us with, certificate and key in one PEM. */
 const certificate = new k8s.core.v1.Secret(

--- a/resources/kubernetes/elsa-gateway/namespace.ts
+++ b/resources/kubernetes/elsa-gateway/namespace.ts
@@ -1,0 +1,23 @@
+import * as k8s from "@pulumi/kubernetes";
+import { provider } from "../../shared/kubernetes/provider.js";
+
+/**
+ * ELSA Gateway gets its own namespace rather than sharing `portal-prod`. It is
+ * a batch job with its own credentials and its own network path — the only
+ * workload here that reaches Skatteetaten — so the blast radius of a mistake
+ * in its config stays with it.
+ */
+const name = "elsa-gateway";
+
+export const namespace = new k8s.core.v1.Namespace(
+	name,
+	{
+		metadata: {
+			name,
+			annotations: {
+				"pulumi.com/skipAwait": "true",
+			},
+		},
+	},
+	{ provider },
+);

--- a/resources/kubernetes/image-pull-secret.ts
+++ b/resources/kubernetes/image-pull-secret.ts
@@ -7,21 +7,6 @@ import { namespace } from "./namespace.js";
 
 const name = "artifact-registry";
 
-export const imagePullSecret = new k8s.core.v1.Secret(
-	name,
-	{
-		metadata: {
-			name,
-			namespace: namespace.metadata.name,
-		},
-		type: "kubernetes.io/dockerconfigjson",
-		stringData: {
-			".dockerconfigjson": dockerConfigJson,
-		},
-	},
-	{ provider },
-);
-
 const ghcrName = "ghcr";
 
 /**
@@ -51,20 +36,52 @@ const ghcrDockerConfigJson = pulumi.secret(
 	),
 );
 
-export const ghcrPullSecret = new k8s.core.v1.Secret(
-	ghcrName,
-	{
-		metadata: {
-			name: ghcrName,
-			namespace: namespace.metadata.name,
+/**
+ * A Secret cannot be read across namespaces, so every namespace running our
+ * images needs its own copy of both.
+ *
+ * `resourceSuffix` only distinguishes the Pulumi resources — the Secrets
+ * themselves are named identically everywhere, which is what lets the single
+ * `imagePullSecrets` list below apply in any namespace. The platform's own
+ * pair passes no suffix so that its resource names, and therefore its state,
+ * are untouched by this being made reusable.
+ */
+export function createImagePullSecrets(
+	namespaceName: pulumi.Input<string>,
+	resourceSuffix = "",
+): void {
+	new k8s.core.v1.Secret(
+		`${name}${resourceSuffix}`,
+		{
+			metadata: {
+				name,
+				namespace: namespaceName,
+			},
+			type: "kubernetes.io/dockerconfigjson",
+			stringData: {
+				".dockerconfigjson": dockerConfigJson,
+			},
 		},
-		type: "kubernetes.io/dockerconfigjson",
-		stringData: {
-			".dockerconfigjson": ghcrDockerConfigJson,
+		{ provider },
+	);
+
+	new k8s.core.v1.Secret(
+		`${ghcrName}${resourceSuffix}`,
+		{
+			metadata: {
+				name: ghcrName,
+				namespace: namespaceName,
+			},
+			type: "kubernetes.io/dockerconfigjson",
+			stringData: {
+				".dockerconfigjson": ghcrDockerConfigJson,
+			},
 		},
-	},
-	{ provider },
-);
+		{ provider },
+	);
+}
+
+createImagePullSecrets(namespace.metadata.name);
 
 /**
  * Both registries are offered. Kubelet tries each until one succeeds, so this


### PR DESCRIPTION
Moves the CronJob and its Secrets out of `portal-prod` into a namespace of their own.

It is the one workload with its own credentials and its own network path out to Skatteetaten, so sharing a namespace with the portal services buys nothing and widens the blast radius of a mistake in its config.

### Pull secrets

A Secret cannot be read across namespaces, so the new namespace needs its own copy of both `artifact-registry` and `ghcr`. Creating them is now a function called once per namespace.

The platform's own pair passes no resource suffix, so their Pulumi resource names are unchanged and this refactor does not replace them — worth confirming in the preview, since replacing those would interrupt image pulls for everything.

### What stays put

The Garage bootstrap Job and `elsa-gateway-bucket-credentials` remain in the `garage` namespace. They need `GARAGE_ADMIN_TOKEN` from `garage-secrets`, which is the same cross-namespace limitation working the other way.

### Timing this merge

Replacing the CronJob deletes the old object, and Kubernetes garbage-collects the Jobs it owns along with it. A run caught mid-flight would be killed, and a message that had been sent to SIMS but not yet marked delivered would be sent again on the next run.

Runs take about ten seconds and fire at :00, :15, :30 and :45, so merging anywhere other than the few seconds after a tick is safe. Worth being deliberate about rather than lucky.